### PR TITLE
fix(INT-829): Group hash entities properly

### DIFF
--- a/helpers/dataTransformations.js
+++ b/helpers/dataTransformations.js
@@ -23,13 +23,13 @@ const getKeys = (keys, items) =>
 
 const groupEntities = (entities) =>
   _.chain(entities)
-    .groupBy(({ isIP, isDomain, type }) =>
+    .groupBy(({ isIP, isDomain, type, isSHA256, isSHA1, isMD5 }) =>
       isIP ? "ip" : 
       isDomain ? "domain" : 
-      type === "MAC" ? "mac" : 
-      type === "MD5" ? "md5" : 
-      type === "SHA1" ? "sha1" : 
-      type === "SHA256" ? "sha256" : 
+      type === "MAC" ? "mac" :
+      isMD5 ? "md5" :
+      isSHA1 ? "sha1" :
+      isSHA256 ? "sha256" :
       "unknown"
     )
     .omit("unknown")

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "./integration.js",
   "name": "chronicle-backstory",
-  "version": "3.1.2-beta",
+  "version": "3.1.3-beta",
   "private": true,
   "license": "MIT",
   "author": "Polarity",


### PR DESCRIPTION
Quick fix for grouping hashes properly.  The issue was that the grouping was being done on the `entity.type` property but for hashes `type` will always just be `hash`.  To check for the specific type of hash you can either check the `types` array or use the boolean flags (which I went with for this PR).

